### PR TITLE
add fish counter

### DIFF
--- a/javascripts/components/river.js
+++ b/javascripts/components/river.js
@@ -13,6 +13,7 @@ const makeBearCards = (arr) => {
                 <button type="button" id="catch-${index}" class="btn inner--button btn-lg mt-3">Catch</button>
               </div>
               <div id="attemptsAndCatchesContainer-${index}" class="mt-3"></div>
+              <div id="catchCounter-${index}" class="catch--counter">Fish Caught: 0</div> 
             </div>
           </div>`
         )
@@ -48,13 +49,24 @@ const catchButtonClick = (arr) => {
                     <div>${catchInfo.type}: ${catchInfo.timeStamp}</div>
                 </div>`
             )
+        catchCounter(catches);
         })
+    })
+}
+
+const catchCounter = (arr) => {
+    arr.forEach((x, index) => {
+        let individualCatches = arr.filter(bear => bear.bearNumber === index);
+        console.log(individualCatches);
+        $(`#catchCounter-${index}`).html(
+            `Fish Caught: ${individualCatches.length}`
+        )
     })
 }
 
 const catchAttemptButtonEvents = (arr) => {
     attemptButtonClick(arr);
-    catchButtonClick(arr);
+    catchButtonClick(arr);;
 }
 
 export { makeBearCards }

--- a/main.css
+++ b/main.css
@@ -43,3 +43,8 @@ body {
 .Catch {
     background: #abffac;
 }
+
+.catch--counter {
+    background: #997255;
+    color: #3a3235;
+}


### PR DESCRIPTION
## Description
Add counter for number of fish caught for each individual bear.

## Related Issue
- #13 

## Motivation and Context
- Allows the user to easily see the total number of fish each bear has caught.

## How Can This Be Tested?
```git fetch origin catch-counter```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)